### PR TITLE
Support Rails 5.1 and report to Rollbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
+pkg/
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "http://rubygems.org"
 
 gemspec
+
+gem 'gemfury'
+gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,16 @@
 require 'rake'
 require 'rake/testtask'
+require 'bundler/gem_tasks'
+require 'gemfury/tasks'
 
 desc "Default task"
 task :default => [ :test ]
+
+# override rubygems' normal release task to use Gemfury
+Rake::Task['release'].clear
+task :release, [:remote] => ["build", "release:guard_clean", "release:source_control_push"] do
+  Rake::Task['fury:release'].invoke(nil, 'patientslikeme')
+end
 
 Rake::TestTask.new do |t|
   t.libs = ['lib', 'test']
@@ -10,3 +18,4 @@ Rake::TestTask.new do |t|
   t.verbose = true
   t.warning = true
 end
+

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -5,15 +5,15 @@ $:.push File.expand_path("../lib", __FILE__)
 require "deadlock_retry/version"
 
 Gem::Specification.new do |s|
-  s.name = %q{deadlock_retry}
+  s.name = %q{openstreetmap-deadlock_retry}
   s.version = DeadlockRetry::VERSION
-  s.authors = ["Jamis Buck", "Mike Perham"]
+  s.authors = ["Jamis Buck", "Mike Perham", "Tom Hughes"]
   s.description = s.summary = %q{Provides automatic deadlock retry and logging functionality for ActiveRecord and MySQL}
-  s.email = %q{mperham@gmail.com}
+  s.email = %q{tom@compton.nu}
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>3.0'
+  s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>5.0'
 end

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -5,7 +5,7 @@ $:.push File.expand_path("../lib", __FILE__)
 require "deadlock_retry/version"
 
 Gem::Specification.new do |s|
-  s.name = %q{openstreetmap-deadlock_retry}
+  s.name = %q{deadlock_retry}
   s.version = DeadlockRetry::VERSION
   s.authors = ["Jamis Buck", "Mike Perham", "Tom Hughes"]
   s.description = s.summary = %q{Provides automatic deadlock retry and logging functionality for ActiveRecord and MySQL}
@@ -14,6 +14,9 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
+
+  s.add_dependency 'rollbar', '~> 2.0'
+
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>5.0'
 end

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -1,107 +1,95 @@
 require 'active_support/core_ext/module/attribute_accessors'
 
 module DeadlockRetry
-  def self.included(base)
-    base.extend(ClassMethods)
-    base.class_eval do
-      class << self
-        alias_method_chain :transaction, :deadlock_handling
+  mattr_accessor :innodb_status_cmd
+
+  DEADLOCK_ERROR_MESSAGES = [
+    "Deadlock found when trying to get lock",
+    "Lock wait timeout exceeded",
+    "deadlock detected"
+  ]
+
+  MAXIMUM_RETRIES_ON_DEADLOCK = 3
+
+
+  def transaction(*objects, &block)
+    retry_count = 0
+
+    check_innodb_status_available
+
+    begin
+      super(*objects, &block)
+    rescue ActiveRecord::StatementInvalid => error
+      raise if in_nested_transaction?
+      if DEADLOCK_ERROR_MESSAGES.any? { |msg| error.message =~ /#{Regexp.escape(msg)}/ }
+        raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
+        retry_count += 1
+        logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
+        log_innodb_status if DeadlockRetry.innodb_status_cmd
+        exponential_pause(retry_count)
+        retry
+      else
+        raise
       end
     end
   end
 
-  mattr_accessor :innodb_status_cmd
+  private
 
-  module ClassMethods
-    DEADLOCK_ERROR_MESSAGES = [
-      "Deadlock found when trying to get lock",
-      "Lock wait timeout exceeded",
-      "deadlock detected"
-    ]
+  WAIT_TIMES = [0, 1, 2, 4, 8, 16, 32]
 
-    MAXIMUM_RETRIES_ON_DEADLOCK = 3
+  def exponential_pause(count)
+    sec = WAIT_TIMES[count-1] || 32
+    # sleep 0, 1, 2, 4, ... seconds up to the MAXIMUM_RETRIES.
+    # Cap the pause time at 32 seconds.
+    sleep(sec) if sec != 0
+  end
 
+  def in_nested_transaction?
+    # open_transactions was added in 2.2's connection pooling changes.
+    connection.open_transactions != 0
+  end
 
-    def transaction_with_deadlock_handling(*objects, &block)
-      retry_count = 0
+  def show_innodb_status
+    self.connection.select_value(DeadlockRetry.innodb_status_cmd)
+  end
 
-      check_innodb_status_available
+  # Should we try to log innodb status -- if we don't have permission to,
+  # we actually break in-flight transactions, silently (!)
+  def check_innodb_status_available
+    return unless DeadlockRetry.innodb_status_cmd == nil
 
+    if self.connection.adapter_name == "MySQL"
       begin
-        transaction_without_deadlock_handling(*objects, &block)
-      rescue ActiveRecord::StatementInvalid => error
-        raise if in_nested_transaction?
-        if DEADLOCK_ERROR_MESSAGES.any? { |msg| error.message =~ /#{Regexp.escape(msg)}/ }
-          raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
-          retry_count += 1
-          logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
-          log_innodb_status if DeadlockRetry.innodb_status_cmd
-          exponential_pause(retry_count)
-          retry
+        mysql_version = self.connection.select_rows('show variables like \'version\'')[0][1]
+        cmd = if mysql_version < '5.5'
+          'show innodb status'
         else
-          raise
+          'show engine innodb status'
         end
-      end
-    end
-
-    private
-
-    WAIT_TIMES = [0, 1, 2, 4, 8, 16, 32]
-
-    def exponential_pause(count)
-      sec = WAIT_TIMES[count-1] || 32
-      # sleep 0, 1, 2, 4, ... seconds up to the MAXIMUM_RETRIES.
-      # Cap the pause time at 32 seconds.
-      sleep(sec) if sec != 0
-    end
-
-    def in_nested_transaction?
-      # open_transactions was added in 2.2's connection pooling changes.
-      connection.open_transactions != 0
-    end
-
-    def show_innodb_status
-       self.connection.select_value(DeadlockRetry.innodb_status_cmd)
-    end
-
-    # Should we try to log innodb status -- if we don't have permission to,
-    # we actually break in-flight transactions, silently (!)
-    def check_innodb_status_available
-      return unless DeadlockRetry.innodb_status_cmd == nil
-
-      if self.connection.adapter_name == "MySQL"
-        begin
-          mysql_version = self.connection.select_rows('show variables like \'version\'')[0][1]
-          cmd = if mysql_version < '5.5'
-            'show innodb status'
-          else
-            'show engine innodb status'
-          end
-          self.connection.select_value(cmd)
-          DeadlockRetry.innodb_status_cmd = cmd
-        rescue
-          logger.info "Cannot log innodb status: #{$!.message}"
-          DeadlockRetry.innodb_status_cmd = false
-        end
-      else
+        self.connection.select_value(cmd)
+        DeadlockRetry.innodb_status_cmd = cmd
+      rescue
+        logger.info "Cannot log innodb status: #{$!.message}"
         DeadlockRetry.innodb_status_cmd = false
       end
+    else
+      DeadlockRetry.innodb_status_cmd = false
     end
+  end
 
-    def log_innodb_status
-      # show innodb status is the only way to get visiblity into why
-      # the transaction deadlocked.  log it.
-      lines = show_innodb_status
-      logger.warn "INNODB Status follows:"
-      lines.each_line do |line|
-        logger.warn line
-      end
-    rescue => e
-      # Access denied, ignore
-      logger.info "Cannot log innodb status: #{e.message}"
+  def log_innodb_status
+    # show innodb status is the only way to get visiblity into why
+    # the transaction deadlocked.  log it.
+    lines = show_innodb_status
+    logger.warn "INNODB Status follows:"
+    lines.each_line do |line|
+      logger.warn line
     end
-
+  rescue => e
+    # Access denied, ignore
+    logger.info "Cannot log innodb status: #{e.message}"
   end
 end
 
-ActiveRecord::Base.send(:include, DeadlockRetry) if defined?(ActiveRecord)
+ActiveRecord::Base.singleton_class.prepend(DeadlockRetry) if defined?(ActiveRecord)

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -25,6 +25,9 @@ module DeadlockRetry
         raise if retry_count >= MAXIMUM_RETRIES_ON_DEADLOCK
         retry_count += 1
         logger.info "Deadlock detected on retry #{retry_count}, restarting transaction"
+        if retry_count == 1
+          Rollbar.warning error, "deadlock_retry gem was triggered", retry: retry_count
+        end
         log_innodb_status if DeadlockRetry.innodb_status_cmd
         exponential_pause(retry_count)
         retry

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
This branch takes tomhughes's removal of `alias_method_chain` (to support Rails 5.1) and adds reporting to Rollbar whenever a deadlock is detected.
